### PR TITLE
Fix broken indentation in manpage template

### DIFF
--- a/man/tessen.5.scd
+++ b/man/tessen.5.scd
@@ -127,7 +127,7 @@ The following options are understood by the configuration file for *tessen*(1):
 	The default web browser that should be used for opening URLs. If this is
 	specified, *xdg-open*(1) will not be used even if it's installed.
 
-  *notify*
+	*notify*
 
 	Whether to send notifications about copied data via *notify-send*(1).
 	Either *true* or *false* (default is *true*).


### PR DESCRIPTION
#43 broke one of the manpage templates

```
> sudo make install
scdoc < man/tessen.5.scd > man/tessen.5
Error at 130:1: Tabs are required for indentation
make: *** [Makefile:51: man/tessen.5] Error 1
```